### PR TITLE
ci: added workflow to check and update Typst dependencies

### DIFF
--- a/.github/workflows/update-typst.yml
+++ b/.github/workflows/update-typst.yml
@@ -1,0 +1,26 @@
+name: Update Typst Packages
+
+on:
+  # Run daily at midnight
+  schedule:
+    - cron: "0 0 * * *"
+  push:
+    branches:
+    - main
+    paths:
+      - "**/*.typ"
+  workflow_dispatch:
+jobs:
+  update_typst_packages:
+    name: Update Typst Packages
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@cargo-binstall
+      - run: cargo binstall typst-upgrade
+      - run: >
+          find . -type f -name "main.typ" -exec dirname {} \; | sort -u | while read dir; do
+           typst-upgrade "$dir"
+          done
+

--- a/typos.toml
+++ b/typos.toml
@@ -2,6 +2,9 @@
 check-filename = true
 check-file = true
 
+[default.extend-words]
+typ = "typ"
+
 [type.png]
 extend-glob = ["*.png"]
 check-file = false


### PR DESCRIPTION
New workflow runs [typst-upgrade](https://github.com/Coekjan/typst-upgrade) on all directories with a `main.typ`. This ensures both the package src and the manual/examples/etc are included.