### PR TITLE
build(publish): removal of `manual/*.typ` in prepare-package

### DIFF
--- a/justscripts/publish.just
+++ b/justscripts/publish.just
@@ -41,6 +41,11 @@ prepare-package:
   cp README.md "$pdir"
   cp LICENSE "$pdir"
 
+  (
+    cd "$pdir/manual"
+    rm -f *.typ
+  )
+
   cd $pdir
   git add .
   git commit -m "added catppuccin version $version"


### PR DESCRIPTION
added step to remove `*.typ` file from the prepared packages `manual` dir