### PR TITLE
refactor(build): refactored justscripts

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,6 +1,8 @@
 mod build "./justscripts/build"
 mod package "./justscripts/package"
 
+set dotenv-load
+
 _default:
   @just --list --justfile {{justfile()}}
 

--- a/justfile
+++ b/justfile
@@ -1,7 +1,6 @@
 mod build "./justscripts/build"
-import "./justscripts/publish.just"
 
-default:
+_default:
   @just --list --justfile {{justfile()}}
 
 @update *opts:
@@ -13,21 +12,6 @@ default:
   typst-upgrade {{ opts }} manual
   typst-upgrade {{ opts }} examples
 
-[group("Build")]
-[doc("Removes the compiled modules, assets, temporary files, and any manuals.")]
-[no-cd]
-@clean:
-  echo "Cleaning up all built files..."
-  rm -rf src/tmThemes assets/previews manual/{.temp,*.pdf} \
-     template/main.typ template/*.webp
-
-[private]
-[no-cd]
-fetch_scripts:
-  #!/usr/bin/env sh
-  set -euo pipefail
-
-  cp -r ./typst-package-template/scripts .
 
 [group("Development")]
 [unix]

--- a/justfile
+++ b/justfile
@@ -3,6 +3,16 @@ mod build "./justscripts/build"
 _default:
   @just --list --justfile {{justfile()}}
 
+[private]
+[no-cd]
+fetch_scripts:
+  #!/usr/bin/env sh
+  set -euo pipefail
+
+  cp -r ./typst-package-template/scripts .
+
+[group("Development")]
+[doc("Updates typst dependencies in the project.")]
 @update *opts:
   #!/usr/bin/env sh
   set -euo pipefail

--- a/justfile
+++ b/justfile
@@ -1,4 +1,5 @@
 mod build "./justscripts/build"
+mod package "./justscripts/package"
 
 _default:
   @just --list --justfile {{justfile()}}

--- a/justscripts/build/mod.just
+++ b/justscripts/build/mod.just
@@ -15,3 +15,12 @@ import "modules.just"
   find . -type f -iname "*.png" -not -path "./tests/*" | xargs oxipng -q -o max --strip safe
 
   echo "\nBuild complete"
+
+[group("Build")]
+[doc("Removes the compiled modules, assets, temporary files, and any manuals.")]
+[no-cd]
+@clean:
+  echo "Cleaning up all built files..."
+  rm -rf src/tmThemes assets/previews manual/{.temp,*.pdf} \
+     template/main.typ template/*.webp
+

--- a/justscripts/package/mod.just
+++ b/justscripts/package/mod.just
@@ -1,5 +1,9 @@
+set dotenv-required
+
+# Ensure there is a .env file in the root of the repository containing
+# the variable ORIGIN_URL, which is a git URL to a fork of the upstream repository.
+
 UPSTREAM_URL := "https://github.com/typst/packages.git"
-FORK_URL := "https://github.com/TimeTravelPenguin/packages.git"
 
 _default:
   @just --list package
@@ -15,11 +19,11 @@ init:
   #!/usr/bin/env sh
   set -euxo pipefail
 
-  git clone {{FORK_URL}} package
+  git clone $ORIGIN_URL package || true
   cd package
 
   # Add upstream
-  git remote add upstream {{UPSTREAM_URL}}
+  git remote add upstream {{UPSTREAM_URL}} || true
 
   # Bootstrap local main
   git fetch upstream --tags --prune

--- a/justscripts/package/mod.just
+++ b/justscripts/package/mod.just
@@ -1,7 +1,39 @@
-GIT_URL := "https://github.com/typst/packages.git"
+UPSTREAM_URL := "https://github.com/typst/packages.git"
+FORK_URL := "https://github.com/TimeTravelPenguin/packages.git"
 
+_default:
+  @just --list package
+
+[group("Packaging")]
+[doc("Prepares the package for release.")]
 [no-cd]
-prepare-package:
+new: init update
+
+[private]
+[no-cd]
+init:
+  #!/usr/bin/env sh
+  set -euxo pipefail
+
+  git clone {{FORK_URL}} package
+  cd package
+
+  # Add upstream
+  git remote add upstream {{UPSTREAM_URL}}
+
+  # Bootstrap local main
+  git fetch upstream --tags --prune
+  git checkout main
+  git reset --hard upstream/main
+
+  # Create feature branch
+  git switch -c "catppuccin-branch"
+  git reset --mixed origin/catppuccin-branch
+
+[group("Packaging")]
+[doc("Updates the package with the latest changes.")]
+[no-cd]
+update:
   #!/usr/bin/env sh
   set -euo pipefail
 
@@ -13,22 +45,6 @@ prepare-package:
   if ! git ls-remote --tags origin | grep -q "refs/tags/v$version"; then
     echo "The tag v$version does not exist in the origin repository. Please create using:"
     echo "  git tag -a \"v$version\" -m \"v$version\" && git push origin \"v$version\""
-    exit 1
-  fi
-
-  if [[ ! -d "package" ]]; then
-    echo "Cloning the package repo..."
-    git clone "{{GIT_URL}}" --depth=1 package
-  fi
-
-  (
-    cd package
-    git switch -C "catppuccin-branch"
-    git reset --hard "origin/main" # Reset branch in case it was modified
-  ) || exit 1
-
-  if [[ -d "$pdir" ]]; then
-    echo "The package directory for Catppuccin version $version already exists. Aborting."
     exit 1
   fi
 
@@ -46,6 +62,3 @@ prepare-package:
     rm -f *.typ
   )
 
-  cd $pdir
-  git add .
-  git commit -m "added catppuccin version $version"


### PR DESCRIPTION
## About
This PR primarily reworks how packaging is prepared and updated.

Previously, the script opened a repo in place, and the user needed to set the tracking manually. Now, it uses a `.env` file to obtain the repo URL for `origin`.

`origin/main` is hard reset to `upstream/main`, and `origin/catppuccin-branch` is reset with `--mixed`. This prevents some issues in odd circumstances where the commit history was lost and commits required a force-push.

Additionally, the script no longer automatically commits. This is left for the user to avoid committing with confusing or pointless commit messages. In the best case, this would simply be `catppuccin:v*.*.*` for the new version of the package. However, if fixes need to be made, the script no longer wipes the commit history and packaging is easier to debug if something goes wrong.

Much like the previous script, if the error of the typst package does not match a valid git tag, there is an error early into the script.

## Remaining Tasks

These tasks need to be completed before requesting the PR for review.
- [x] Replace the hard-coded string `FORK_URL` with `ORIGIN_URL` and have the value set in a `.env` file.